### PR TITLE
Multithread the Quantum RNG and add timeout

### DIFF
--- a/src/circuit_solver.py
+++ b/src/circuit_solver.py
@@ -4,6 +4,7 @@ from qiskit import execute
 from qiskit.circuit import QuantumRegister, QuantumCircuit
 from quantuminspire.credentials import get_authentication
 from quantuminspire.qiskit import QI
+import threading
 
 QI_URL = os.getenv('API_URL', 'https://api.quantum-inspire.com/')
 
@@ -12,6 +13,7 @@ QI.set_authentication(authentication, QI_URL)
 
 qi_backend = QI.get_backend('QX single-node simulator')
 starmon_qi_backend = QI.get_backend('Starmon-5')
+coin_flip_return = None
 
 
 def add_gate_to_circ(qubit_index, gate_char, qr, qc, control_qubit_index=None):
@@ -98,7 +100,7 @@ def resolve_circuit(gates_list):
     return res
 
 
-def quantum_coin_flip():
+def quantum_coin_flip(list):
     """
     does a random measurement on an qubit in superposition, then
     returns a 0 or 1, with p(0) = p(1) = 50%
@@ -109,8 +111,10 @@ def quantum_coin_flip():
 
     qc.measure_all()
 
-    qi_job = execute(qc, backend=starmon_qi_backend, shots=1)
+    qi_job = execute(qc, backend=qi_backend, shots=1)
     qi_result = qi_job.result()
 
     # return measurement result: 0 or 1
-    return next(iter(qi_result.get_counts(qc).items()))[0]
+    list.append(next(iter(qi_result.get_counts(qc).items()))[0])
+
+

--- a/src/circuit_solver.py
+++ b/src/circuit_solver.py
@@ -111,7 +111,7 @@ def quantum_coin_flip(list):
 
     qc.measure_all()
 
-    qi_job = execute(qc, backend=qi_backend, shots=1)
+    qi_job = execute(qc, backend=starmon_qi_backend, shots=1)
     qi_result = qi_job.result()
 
     # return measurement result: 0 or 1

--- a/src/circuit_solver.py
+++ b/src/circuit_solver.py
@@ -13,7 +13,6 @@ QI.set_authentication(authentication, QI_URL)
 
 qi_backend = QI.get_backend('QX single-node simulator')
 starmon_qi_backend = QI.get_backend('Starmon-5')
-coin_flip_return = None
 
 
 def add_gate_to_circ(qubit_index, gate_char, qr, qc, control_qubit_index=None):

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import time
 from model import *
 from util import Views
 from view import *
+import threading
 
 FPS = 30
 
@@ -65,8 +66,15 @@ class Game:
                             break
 
                         self.state.take_turn(row, col)
-                        winner, winstate = self.state.board.check_win()
+                        cycle = self.state.board.has_cycle(row, col)
+                        if cycle is not None:
+                            thread1 = threading.Thread(target=self.state.board.resolve_cycle, args=(cycle,))
+                            thread1.start()
+                            self.drawer.draw_quantum_xo(self.state.board, row, col)
+                            self.drawer.draw_status_message("Resolving superposition, please wait some time...")
+                            thread1.join()
 
+                        winner, winstate = self.state.board.check_win()
                         if winner is False:
                             break
 

--- a/src/model.py
+++ b/src/model.py
@@ -217,17 +217,6 @@ class Board:
             self.graph.add_edge(self.prevSubTurnIndex, new_index, char)
             self.prevSubTurnIndex = None
 
-            # cycle = self.graph.get_cycle(new_index)
-            # if cycle is not None:
-            #     tile_to_mark = resolve_superposition(self.board, self.graph, cycle)
-            #
-            #     # Mark all nodes in the cycle as final
-            #     for node_id in tile_to_mark.keys():
-            #         row, col = GameProperties.id_to_position(node_id)
-            #         self.final[row][col] = int(tile_to_mark[node_id][1:])
-            #
-            #     # Remove all edges and nodes that were in the cycle
-            #     self.graph.remove_cycle(cycle)
         # When there is 1 possible spot left:
         elif self.prevSubTurnIndex == new_index:
             self.board[row][col] = char[0]

--- a/src/model.py
+++ b/src/model.py
@@ -219,7 +219,7 @@ class Board:
 
             cycle = self.graph.get_cycle(new_index)
             if cycle is not None:
-                tile_to_mark = resolve_superposition(self.board, self.graph, cycle, quantic=False)
+                tile_to_mark = resolve_superposition(self.board, self.graph, cycle)
 
                 # Mark all nodes in the cycle as final
                 for node_id in tile_to_mark.keys():

--- a/src/model.py
+++ b/src/model.py
@@ -217,21 +217,48 @@ class Board:
             self.graph.add_edge(self.prevSubTurnIndex, new_index, char)
             self.prevSubTurnIndex = None
 
-            cycle = self.graph.get_cycle(new_index)
-            if cycle is not None:
-                tile_to_mark = resolve_superposition(self.board, self.graph, cycle)
-
-                # Mark all nodes in the cycle as final
-                for node_id in tile_to_mark.keys():
-                    row, col = GameProperties.id_to_position(node_id)
-                    self.final[row][col] = int(tile_to_mark[node_id][1:])
-
-                # Remove all edges and nodes that were in the cycle
-                self.graph.remove_cycle(cycle)
+            # cycle = self.graph.get_cycle(new_index)
+            # if cycle is not None:
+            #     tile_to_mark = resolve_superposition(self.board, self.graph, cycle)
+            #
+            #     # Mark all nodes in the cycle as final
+            #     for node_id in tile_to_mark.keys():
+            #         row, col = GameProperties.id_to_position(node_id)
+            #         self.final[row][col] = int(tile_to_mark[node_id][1:])
+            #
+            #     # Remove all edges and nodes that were in the cycle
+            #     self.graph.remove_cycle(cycle)
         # When there is 1 possible spot left:
         elif self.prevSubTurnIndex == new_index:
             self.board[row][col] = char[0]
             self.final[row][col] = int(char[1:])
+
+    def has_cycle(self, row, col):
+        """
+        Check if the game in this state has a cycle.
+        """
+        if self.prevSubTurnIndex is None:
+            new_index = GameProperties.position_to_id(row, col)
+            cycle = self.graph.get_cycle(new_index)
+            if cycle is not None:
+                return cycle
+        return None
+
+    def resolve_cycle(self, cycle):
+        """
+        The cycle that is provided as an argument is resolved, by collapsing the superposition
+        and deleting the cycle from the graph.
+        """
+
+        tile_to_mark = resolve_superposition(self.board, self.graph, cycle)
+
+        # Mark all nodes in the cycle as final
+        for node_id in tile_to_mark.keys():
+            row, col = GameProperties.id_to_position(node_id)
+            self.final[row][col] = int(tile_to_mark[node_id][1:])
+
+        # Remove all edges and nodes that were in the cycle
+        self.graph.remove_cycle(cycle)
 
 
 class GameState:

--- a/src/superposition_solver.py
+++ b/src/superposition_solver.py
@@ -19,16 +19,15 @@ def resolve_superposition(board, graph, cycle, quantic=True):
     # decide the coin toss
     # coin_toss_res = quantum_coin_flip()
     if quantic:
-        #todo: thread this statement
         list_argument = []
         thread1 = threading.Thread(target=quantum_coin_flip, args=(list_argument,))
         thread1.start()
         thread1.join(2.5)
         if len(list_argument) == 0:
-            print("Timeout happened :(")
+            print("Response was too slow, classical result.")
             coin_toss_res = getrandbits(1)
         else:
-            print("Quantic result!")
+            print("Quantum computer responded, the result is quantic!")
             coin_toss_res = int(list_argument[0])
     else:
         coin_toss_res = getrandbits(1)
@@ -41,7 +40,7 @@ def resolve_superposition(board, graph, cycle, quantic=True):
 
     # Use a queue of tuples to resolve all edges, where the tuples contain:
     # (key of edge, id of node where this key must land)
-    queue = Queue(maxsize=9)
+    queue = Queue(maxsize=GameProperties.get_instance().dim ** 2)
     queue.put((edge_id, node_id))
     return_dict = defaultdict(lambda: -1)
     decided_node_ids = []

--- a/src/superposition_solver.py
+++ b/src/superposition_solver.py
@@ -1,6 +1,7 @@
 from random import getrandbits
 from queue import Queue
 from collections import defaultdict
+import threading
 
 from circuit_solver import quantum_coin_flip
 from util import GameProperties
@@ -18,7 +19,17 @@ def resolve_superposition(board, graph, cycle, quantic=True):
     # decide the coin toss
     # coin_toss_res = quantum_coin_flip()
     if quantic:
-        coin_toss_res = quantum_coin_flip()
+        #todo: thread this statement
+        list_argument = []
+        thread1 = threading.Thread(target=quantum_coin_flip, args=(list_argument,))
+        thread1.start()
+        thread1.join(2.5)
+        if len(list_argument) == 0:
+            print("Timeout happened :(")
+            coin_toss_res = getrandbits(1)
+        else:
+            print("Quantic result!")
+            coin_toss_res = int(list_argument[0])
     else:
         coin_toss_res = getrandbits(1)
 

--- a/src/superposition_solver.py
+++ b/src/superposition_solver.py
@@ -22,7 +22,7 @@ def resolve_superposition(board, graph, cycle, quantic=True):
         list_argument = []
         thread1 = threading.Thread(target=quantum_coin_flip, args=(list_argument,))
         thread1.start()
-        thread1.join(2.5)
+        thread1.join(7.5)
         if len(list_argument) == 0:
             print("Response was too slow, classical result.")
             coin_toss_res = getrandbits(1)

--- a/src/view.py
+++ b/src/view.py
@@ -9,7 +9,7 @@ NEW_IMG_HEIGHT = 40
 
 class Drawer:
     def __init__(self, RATIO=16 / 10, HEIGHT=900):
-    # def __init__(self, RATIO=16/10, HEIGHT=820):
+        # def __init__(self, RATIO=16/10, HEIGHT=820):
         # general settings
         self.button_group = None
 
@@ -96,17 +96,20 @@ class Drawer:
         """
         self.screen.fill(self.BG)
 
-        text = "Welcome to Quantum Tic-Tac-Toe, *Qubic*! Instead of X's and O's, you can place two *basis states* " \
-               "of a qubit, namely: |0> and |1>. On each move, the current player marks *two* squares with their states, " \
+        text = "Welcome to Quantum Tic-Tac-Toe! Instead of X's and O's, you can place two *basis states* " \
+               "of a qubit, namely: |0> and |1>. On each move, the current player marks *two* squares with their " \
+               "states, " \
                "and each state is subscripted with the number of the move. The two squares are marked and called " \
                "*entangled*. Once a *cyclic entanglement*, a cycle in the entanglement graph, occurs, a measurement is " \
-               "triggered and the cycle collapses to only one of the states on the square. Like in classical " \
-               "tic-tac-toe, the goal is achieve 3 connected states (for the 3x3 board) or 4 connected states " \
-               "(for 4x4 and 5x5 boards). Explore the quantum concepts of superposition, entanglement, and measurement; " \
-               "and increase your winning probability."
+               "triggered on an actual quantum computer and the cycle collapses to only one of the states on the" \
+               " square. This can take up to 2.5 seconds, so please wait for the program to continue." \
+               " Like in classical tic-tac-toe, the goal is achieve 3" \
+               " connected states (for the 3x3 board) or 4 connected states (for 4x4 and 5x5 boards). Explore the" \
+               "quantum concepts of superposition, entanglement, and measurement; and increase your winning " \
+               "probability. "
 
         # keep margin low for text to be at top of window
-        margin = 100
+        margin = 50
         rect = pg.Rect(margin, margin,
                        self.WIDTH - 2 * margin, 2 * self.HEIGHT / 3)
         self.draw_text(text, (255, 255, 255), rect, self.mono_font)
@@ -315,7 +318,7 @@ class Drawer:
         """
         Method for drawing the scoreboard at the bottom of the screen
         """
-        message_points = "Player 1: {} points   Player 2: {} points"\
+        message_points = "Player 1: {} points   Player 2: {} points" \
             .format(game_state.player1_score, game_state.player2_score)
         message_played = "Games played: {} game".format(game_state.games_played) \
                          + ("s" if game_state.games_played != 1 else "")

--- a/src/view.py
+++ b/src/view.py
@@ -104,7 +104,7 @@ class Drawer:
                "and each state is subscripted with the number of the move. The two squares are marked and called " \
                "*entangled*. Once a *cyclic entanglement*, a cycle in the entanglement graph, occurs, a measurement is " \
                "triggered on an actual quantum computer and the cycle collapses to only one of the states on the" \
-               " square. This can take up to 2.5 seconds, so please wait for the program to continue." \
+               " square. This can take up to 5 seconds, so please wait for the program to continue." \
                " Like in classical tic-tac-toe, the goal is achieve 3" \
                " connected states (for the 3x3 board) or 4 connected states (for 4x4 and 5x5 boards). Explore the" \
                "quantum concepts of superposition, entanglement, and measurement; and increase your winning " \


### PR DESCRIPTION
In this branch, I've updated the game to be multithreaded, so a different thread is used to execute the coin flip on a quantum computer, and also adds a timeout of 2.5 seconds, after which it falls back onto a classical coin flip to decide the collapse of a cycle.